### PR TITLE
Zipファイルのアップロード周りの体験改善

### DIFF
--- a/src/components/Editor/UploadFileEditor.vue
+++ b/src/components/Editor/UploadFileEditor.vue
@@ -28,6 +28,7 @@ const onRemove = async () => {
 <template>
   <NUpload
     ref="uploadRef"
+    accept=".zip"
     directory-dnd
     :max="1"
     :multiple="false"

--- a/src/pages/Games/Detail/File.vue
+++ b/src/pages/Games/Detail/File.vue
@@ -25,28 +25,31 @@ const isUploadFileModalOpen = ref(false)
 const handleCancelFile = () => {
   isUploadFileModalOpen.value = false
 }
-const handleUploadFile = (type: string, entryPoint: string, content: File) => {
-  ;(async () => {
-    const res = await postGameFile.refetch(
-      String(gameId.value),
-      type,
-      entryPoint,
-      content
-    )
-    if (res && res.type === 'error') {
-      res.error.response?.status === 400
-        ? alert(
-            `ファイルのアップロードに失敗しました。入力を確認してください。
+const handleUploadFile = async (
+  type: string,
+  entryPoint: string,
+  content: File
+) => {
+  const res = await postGameFile.refetch(
+    String(gameId.value),
+    type,
+    entryPoint,
+    content
+  )
+  if (res && res.type === 'error') {
+    res.error.response?.status === 400
+      ? alert(
+          `ファイルのアップロードに失敗しました。入力を確認してください。
 メッセージ: ${res.error.response.data.message}` //TODO: ちゃんとしたアラートの何かを出す
-          )
-        : alert('エラーが発生しました')
-      return
-    }
-    isUploadFileModalOpen.value = false
-    getGameFiles.refetch(String(gameId.value))
-  })()
+        )
+      : alert('エラーが発生しました')
+    return
+  }
+  isUploadFileModalOpen.value = false
+  getGameFiles.refetch(String(gameId.value))
 }
 </script>
+
 <template>
   <NModal
     preset="card"

--- a/src/pages/Games/Detail/File.vue
+++ b/src/pages/Games/Detail/File.vue
@@ -27,7 +27,21 @@ const handleCancelFile = () => {
 }
 const handleUploadFile = (type: string, entryPoint: string, content: File) => {
   ;(async () => {
-    await postGameFile.refetch(String(gameId.value), type, entryPoint, content)
+    const res = await postGameFile.refetch(
+      String(gameId.value),
+      type,
+      entryPoint,
+      content
+    )
+    if (res && res.type === 'error') {
+      res.error.response?.status === 400
+        ? alert(
+            `ファイルのアップロードに失敗しました。入力を確認してください。
+メッセージ: ${res.error.response.data.message}` //TODO: ちゃんとしたアラートの何かを出す
+          )
+        : alert('エラーが発生しました')
+      return
+    }
     isUploadFileModalOpen.value = false
     getGameFiles.refetch(String(gameId.value))
   })()


### PR DESCRIPTION
- **:sparkles: ゲームはzipファイルのみをアップロードできるようにする**
- **:sparkles: ゲームファイルアップロード時、エラーが返ってきたらアラート出す**
- **:sparkles: ファイル提出後、ボタンをloadingにする**

zipファイルじゃなかったりエントリーポイントが存在しなかったりしたら400が返って来るようになったので、そのことがユーザーに分かるようにした。alertの部分はとりあえず。工大祭までに使いたい