### PR TITLE
ファイルアップロードのacceptを修正

### DIFF
--- a/src/components/Editor/NewGameFileEditor.vue
+++ b/src/components/Editor/NewGameFileEditor.vue
@@ -114,6 +114,7 @@ const handleSubmit = async () => {
     </NFormItem>
     <NFormItem label="zip ファイル" path="contentValue">
       <UploadFileEditor
+        accept=".zip"
         :onUpload="(file: File | null) => { contentValue = file }"
       />
     </NFormItem>

--- a/src/components/Editor/UploadFileEditor.vue
+++ b/src/components/Editor/UploadFileEditor.vue
@@ -11,6 +11,7 @@ import { ref } from 'vue'
 
 const props = defineProps<{
   onUpload?: (file: File | null) => void
+  accept?: string
 }>()
 
 const uploadRef = ref<UploadInst | null>(null)
@@ -28,7 +29,7 @@ const onRemove = async () => {
 <template>
   <NUpload
     ref="uploadRef"
-    accept=".zip"
+    :accept="accept"
     directory-dnd
     :max="1"
     :multiple="false"

--- a/src/pages/Games/Detail/Image.vue
+++ b/src/pages/Games/Detail/Image.vue
@@ -45,7 +45,10 @@ const handleUploadImage = (data: File | null) => {
     @close="handleCancelImage"
     @maskClick="handleCancelImage"
   >
-    <UploadImageEditor :onUpload="handleUploadImage" />
+    <UploadImageEditor
+      accept=".png,.jpeg,.jpg,.gif"
+      :onUpload="handleUploadImage"
+    />
   </NModal>
   <NSpace class="py-10 px-12 gap-10" vertical>
     <GameImagePageHeader

--- a/src/pages/Games/Detail/Video.vue
+++ b/src/pages/Games/Detail/Video.vue
@@ -45,7 +45,7 @@ const handleUploadVideo = (data: File | null) => {
     @close="handleCancelVideo"
     @maskClick="handleCancelVideo"
   >
-    <UploadImageEditor :onUpload="handleUploadVideo" />
+    <UploadImageEditor accept=".mp4" :onUpload="handleUploadVideo" />
   </NModal>
   <NSpace class="py-10 px-12 gap-10" vertical>
     <GameVideoPageHeader


### PR DESCRIPTION
画像や動画をアップロードするところでも、エクスプローラーからの選択画面がzipのみになってしまっていた。:pray:

- **:bug: acceptの種類を受け取れるように**
- **:bug: ゲームファイルはzipだけにする**
- **:adhesive_bandage: 他のファイル形式も指定**
