### PR TITLE
:sparkles: botを除外するようにする

### DIFF
--- a/src/pages/Editions/Detail/Index.vue
+++ b/src/pages/Editions/Detail/Index.vue
@@ -19,7 +19,7 @@ const patchEdition = useApi(apis.patchEdition)
 getEdition.refetch(String(editionId.value))
 
 const getEditionGames = useApi(apis.getEditionGames)
-const postEditionGame = useApi(apis.postEditionGame)
+const patchEditionGame = useApi(apis.patchEditionGame)
 getEditionGames.refetch(String(editionId.value))
 
 const isShowPatchEditionModal = ref(false)
@@ -35,7 +35,7 @@ const handleCancelEdition = () => {
 }
 
 const handleAddGame = async (data: PatchEditionGameRequest) => {
-  await postEditionGame.refetch(String(editionId.value), data)
+  await patchEditionGame.refetch(String(editionId.value), data)
   isShowAddGameModal.value = false
   getEditionGames.refetch(String(editionId.value))
 }

--- a/src/stores/users.ts
+++ b/src/stores/users.ts
@@ -11,7 +11,7 @@ export const useUsersStore = defineStore('users', () => {
 
   // Users を取得する
   const refetch = async () => {
-    const res = await getUsersApi.refetch()
+    const res = await getUsersApi.refetch(false)
     if (res?.type === 'success') {
       users.value = new Map(res.data.map(u => [u.id, u]))
     }


### PR DESCRIPTION
postEditionGame は 名前はposだが PATCH メソッドを使っていたのに気づいてサーバー側でOpenAPIを直したんですが、その際にidを変えてしまってフロント側の生成される関数名と一致しなくなっていました。そのため、フロントで呼び出す関数名を新しい方に修正しました